### PR TITLE
Minor update to Numpy sctypeDict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ pytest.xml
 
 docs_exp/
 docs/run_livereload.py
+
+myenv

--- a/mprod/dimensionality_reduction/_tcam.py
+++ b/mprod/dimensionality_reduction/_tcam.py
@@ -10,8 +10,8 @@ from ..decompositions import svdm
 from .._misc import _assert_order_and_mdim
 from .._ml_helpers import MeanDeviationForm
 
-_float_types = [np.typeDict[c] for c in 'efdg'] + [float]
-_int_types = [np.typeDict[c] for c in 'bhip'] + [int]
+_float_types = [np.sctypeDict[c] for c in 'efdg'] + [float]
+_int_types = [np.sctypeDict[c] for c in 'bhip'] + [int]
 
 
 def _pinv_diag(diag_tensor):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.21
+numpy>=1.19.2
 scikit-learn>=0.24.1
 scipy>=1.5.3
 dataclasses>=0.7; python_version < '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.19.2
+numpy>=1.21
 scikit-learn>=0.24.1
 scipy>=1.5.3
 dataclasses>=0.7; python_version < '3.7'


### PR DESCRIPTION
It seems Numpy has deprecated `typeDict` in newer versions. This minor update should fix warnings and/or issues when runnning with newer versions of Numpy. 

EDIT: Sorry it is clunky, also added an entry in the `.gitignore` file for a virtual env folder when developing locally. 